### PR TITLE
Styling changes.  Fix local serving to match #397.

### DIFF
--- a/config/common.js
+++ b/config/common.js
@@ -38,7 +38,6 @@ export const build = {
   logLevel: 'info',
   plugins: [
     progress(),
-    cleanPlugin(),
     svgrPlugin(),
     copyStaticFiles({
       src: assetsDir,

--- a/config/serve.js
+++ b/config/serve.js
@@ -50,9 +50,9 @@ const proxyRequestHandler = ((options, res) => http.request(options, (proxyRes) 
 
 
 esbuild.serve({
-  port: SERVE_PORT,
+  port: SERVE_PORT - 1,
   servedir: common.build.outdir,
-}, {}).then((result) => {
+}, common.build).then((result) => {
   // The result tells us where esbuild's local server is
   const {host, port} = result
 
@@ -70,8 +70,8 @@ esbuild.serve({
 
     // Forward the body of the request to esbuild
     req.pipe(proxyReq, {end: true})
-  }).listen()
-  console.log(`serving on http://localhost:${port} and watching...`)
+  }).listen(SERVE_PORT)
+  console.log(`serving on http://localhost:${SERVE_PORT} and watching...`)
 }).catch((error) => {
   console.error(`could not start serving: `, error)
   process.exit(1)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.0.0-r449",
+  "version": "1.0.0-r450",
   "main": "src/index.jsx",
   "homepage": "https://github.com/bldrs-ai/Share",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.0.0-r419",
+  "version": "1.0.0-r449",
   "main": "src/index.jsx",
   "homepage": "https://github.com/bldrs-ai/Share",
   "bugs": {

--- a/src/Components/ExpansionPanel.jsx
+++ b/src/Components/ExpansionPanel.jsx
@@ -2,7 +2,6 @@ import React, {useState, useEffect} from 'react'
 import Accordion from '@mui/material/Accordion'
 import AccordionSummary from '@mui/material/AccordionSummary'
 import AccordionDetails from '@mui/material/AccordionDetails'
-import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import {makeStyles, useTheme} from '@mui/styles'
 import CaretIcon from '../assets/2D_Icons/Caret.svg'
@@ -40,9 +39,7 @@ export default function Property({detail, summary, expandState}) {
         </Typography>
       </AccordionSummary>
       <AccordionDetails>
-        <Box sx={{marginLeft: '-30px'}}>
-          {detail}
-        </Box>
+        {detail}
       </AccordionDetails>
     </Accordion>
   )
@@ -55,6 +52,12 @@ const useStyles = makeStyles((theme) => ({
       width: '100%',
       padding: 0,
       borderBottom: `.5px solid ${theme.palette.highlight.dark}`,
+    },
+    '& .MuiAccordionSummary-root.Mui-expanded': {
+      marginBottom: '0.5em',
+    },
+    '& .MuiAccordionDetails-root': {
+      padding: 0,
     },
     '& svg': {
       width: '14px',

--- a/src/Components/ItemProperties.jsx
+++ b/src/Components/ItemProperties.jsx
@@ -93,6 +93,11 @@ const useStyles = makeStyles((theme) => ({
       padding: '4px 0px',
       // borderBottom: `.2px solid ${theme.palette.highlight.dark}`,
     },
+    '& td:hover': {
+      whiteSpace: 'normal',
+      overflowY: 'scroll',
+      textOverflow: 'clip',
+    },
     '& td::-webkit-scrollbar': {
       display: 'none',
     },

--- a/src/Components/ItemProperties.jsx
+++ b/src/Components/ItemProperties.jsx
@@ -88,9 +88,10 @@ const useStyles = makeStyles((theme) => ({
       verticalAlign: 'top',
       whiteSpace: 'nowrap',
       overflowY: 'scroll',
+      textOverflow: 'ellipsis',
       cursor: 'default',
       padding: '4px 0px',
-      borderBottom: `.2px solid ${theme.palette.highlight.dark}`,
+      // borderBottom: `.2px solid ${theme.palette.highlight.dark}`,
     },
     '& td::-webkit-scrollbar': {
       display: 'none',
@@ -100,7 +101,6 @@ const useStyles = makeStyles((theme) => ({
       width: '100%',
       overflow: 'hidden',
       borderSpacing: 0,
-      paddingLeft: '10px',
     },
     '& .MuiSwitch-root': {
       float: 'right',
@@ -108,6 +108,7 @@ const useStyles = makeStyles((theme) => ({
     '& .MuiSwitch-track': {
       backgroundColor: theme.palette.highlight.secondary,
       opacity: 0.8,
+      border: 'solid 2px grey',
     },
     '& .MuiSwitch-thumb': {
       backgroundColor: theme.palette.highlight.main,
@@ -130,7 +131,6 @@ const useStyles = makeStyles((theme) => ({
   },
   psetContainer: {
     marginTop: '20px',
-    marginLeft: '10px',
   },
   psetTitle: {
     position: 'sticky',

--- a/src/Components/SideDrawerPanels.jsx
+++ b/src/Components/SideDrawerPanels.jsx
@@ -60,7 +60,7 @@ export function PropertiesPanel() {
       <div className={classes.contentContainerProperties}>
         {selectedElement ?
           <ItemProperties/> :
-          <Box sx={{width: '100%', paddingLeft: '10px'}}>
+          <Box sx={{width: '100%'}}>
             <Typography
               variant='h1'
               sx={{textAlign: 'left'}}
@@ -94,7 +94,6 @@ const useStyles = makeStyles((theme) => ({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    paddingLeft: '10px',
     borderRadius: '5px',
   },
   title: {

--- a/src/Theme.jsx
+++ b/src/Theme.jsx
@@ -176,33 +176,6 @@ function loadTheme(mode) {
         disableRipple: true,
       },
     },
-    // https://stackoverflow.com/questions/63249267/how-can-i-override-the-style-of-the-material-ui-switch-component-when-checked
-    /*
-    MuiSwitch: {
-      styleOverrides: {
-        switchBase: {
-          // Controls default (unchecked) color for the thumb
-          color: 'red',
-        },
-        colorSecondary: {
-          '&$checked': {
-            // Controls checked color for the thumb
-            color: 'green',
-          },
-        },
-        track: {
-          // Controls default (unchecked) color for the track
-          'opacity': 0.2,
-          'backgroundColor': 'blue',
-          '$checked$checked + &': {
-            // Controls checked color for the track
-            opacity: 0.7,
-            backgroundColor: 'yellow',
-          },
-        },
-      },
-    },
-    */
   }
   const theme = {
     components: components,

--- a/src/Theme.jsx
+++ b/src/Theme.jsx
@@ -65,7 +65,7 @@ function loadTheme(mode) {
   const darkGreen = '#459A47'
   const darkGrey = '#707070'
   const lightGrey = '#CCCCCC'
-  const fontFamily = 'Helvetica'
+  const fontFamily = 'sans-serif'
   const lime = '#4EEF4B'
   const day = {
     primary: {
@@ -101,24 +101,29 @@ function loadTheme(mode) {
       lime: lime,
     },
   }
+  const fontSize = '1rem'
+  const lineHeight = '1.5em'
+  const letterSpacing = 'normal'
+  const fontWeight = '400'
+  const fontWeightBold = '600'
   const typography = {
-    fontWeightRegular: 400,
-    fontWeightBold: 400,
-    fontWeightMedium: 400,
-    h1: {fontSize: '1.2rem', lineHeight: '1.5em', letterSpacing: '.03em', fontWeight: '400', fontFamily: fontFamily},
-    h2: {fontSize: '1.0rem', lineHeight: '1.5em', letterSpacing: '.03em', fontWeight: '400', fontFamily: fontFamily},
-    h3: {fontSize: '1.1rem', lineHeight: '1.5em', letterSpacing: '.03em', fontWeight: '200', fontFamily: fontFamily},
-    h4: {fontSize: '1.0rem', lineHeight: '1.2em', letterSpacing: '.03em', fontWeight: '400', fontFamily: fontFamily},
-    h5: {fontSize: '1.0rem', lineHeight: '1.5em', letterSpacing: '.03em', fontWeight: '400', fontFamily: fontFamily},
-    p: {fontSize: '1.0rem', lineHeight: '1.5em', letterSpacing: '.03em', fontWeight: '400', fontFamily: fontFamily},
-    tree: {fontSize: '1.1rem', lineHeight: '1.5em', letterSpacing: '.03em', fontWeight: '400', fontFamily: fontFamily},
-    propTitle: {fontSize: '1.1rem', lineHeight: '1.5em', letterSpacing: '.03em', fontWeight: '400', fontFamily: fontFamily},
+    fontWeightRegular: fontWeight,
+    fontWeightBold,
+    fontWeightMedium: fontWeight,
+    h1: {fontSize: '1.3rem', lineHeight, letterSpacing, fontWeight, fontFamily},
+    h2: {fontSize: '1.2rem', lineHeight, letterSpacing, fontWeight, fontFamily},
+    h3: {fontSize: '1.1rem', lineHeight, letterSpacing, fontWeight, fontFamily},
+    h4: {fontSize, lineHeight, letterSpacing, fontWeight, fontFamily},
+    h5: {fontSize, lineHeight, letterSpacing, fontWeight, fontFamily},
+    p: {fontSize, lineHeight, letterSpacing, fontWeight, fontFamily},
+    tree: {fontSize, lineHeight, letterSpacing, fontWeight, fontFamily},
+    propTitle: {fontSize, lineHeight, letterSpacing, fontWeight: fontWeightBold, fontFamily},
     propValue: {
-      fontSize: '1.1rem',
-      lineHeight: '1.5em',
-      letterSpacing: '.03em',
-      fontWeight: '200',
-      fontFamily: fontFamily,
+      fontSize,
+      lineHeight,
+      letterSpacing,
+      fontWeight,
+      fontFamily,
       marginLeft: '4px'},
   }
   // TODO(pablo): still not sure how this works.  The docs make it
@@ -171,6 +176,33 @@ function loadTheme(mode) {
         disableRipple: true,
       },
     },
+    // https://stackoverflow.com/questions/63249267/how-can-i-override-the-style-of-the-material-ui-switch-component-when-checked
+    /*
+    MuiSwitch: {
+      styleOverrides: {
+        switchBase: {
+          // Controls default (unchecked) color for the thumb
+          color: 'red',
+        },
+        colorSecondary: {
+          '&$checked': {
+            // Controls checked color for the thumb
+            color: 'green',
+          },
+        },
+        track: {
+          // Controls default (unchecked) color for the track
+          'opacity': 0.2,
+          'backgroundColor': 'blue',
+          '$checked$checked + &': {
+            // Controls checked color for the track
+            opacity: 0.7,
+            backgroundColor: 'yellow',
+          },
+        },
+      },
+    },
+    */
   }
   const theme = {
     components: components,

--- a/src/utils/itemProperties.jsx
+++ b/src/utils/itemProperties.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import debug from './debug'
-import Box from '@mui/material/Typography'
 import Typography from '@mui/material/Typography'
 import {deref, decodeIFCString} from '@bldrs-ai/ifclib'
 import {stoi} from './strings'
@@ -26,7 +25,7 @@ export async function createPropertyTable(model, ifcProps, serial = 0, isPset = 
         <tr key='ifcType'>
           <td>
             <Typography variant='propTitle' >IFC Type:</Typography>
-            {paragraphMaybeWithTooltip(ifcProps.constructor.name)}
+            <Typography variant='propValue'>{ifcProps.constructor.name}</Typography>
           </td>
         </tr>)
   }
@@ -232,7 +231,6 @@ export async function hasProperties(model, hasPropertiesArr, serial) {
  * @return {object} The react component
  */
 function Row({d1, d2}) {
-  const keyLength = d1.length
   if (d1 === null || d1 === undefined ||
     d2 === null || d2 === undefined) {
     debug().warn('Row with invalid data: ', d1, d2)
@@ -240,8 +238,8 @@ function Row({d1, d2}) {
   return (
     <tr>
       <td colSpan={2} >
-        <Typography variant='propTitle' > {d1}:</Typography>
-        <Typography variant='propValue'>{paragraphMaybeWithTooltip(d2, keyLength )}</Typography>
+        <Typography variant='propTitle' >{d1}:</Typography>
+        <Typography variant='propValue'>{d2}</Typography>
       </td>
     </tr>
   )
@@ -258,26 +256,4 @@ function Row({d1, d2}) {
  */
 const dms = (deg, min, sec) => {
   return `${deg}° ${min}' ${sec}''`
-}
-
-
-/**
- * If string is longer than maxWidth characters, wrap it in a tooltip.
- * Otherwise wrap it in a paragraph.
- *
- * @param {string} str
- * @param {number} maxWidth (default 20)
- * @return {object} React component
- */
-function paragraphMaybeWithTooltip(str, keyLength, maxWidth = 40) {
-  const inner = (<Typography variant='propValue'>{str}</Typography>)
-  const propLength = str.length + keyLength
-  return (
-    propLength > maxWidth ?
-    <Box
-      component="span"
-    >
-      {inner}
-    </Box> : inner
-  )
 }

--- a/src/utils/itemProperties.jsx
+++ b/src/utils/itemProperties.jsx
@@ -3,7 +3,6 @@ import debug from './debug'
 import Box from '@mui/material/Typography'
 import Typography from '@mui/material/Typography'
 import {deref, decodeIFCString} from '@bldrs-ai/ifclib'
-import ScrollIcon from '../assets/2D_Icons/Scroll.svg'
 import {stoi} from './strings'
 
 
@@ -278,7 +277,7 @@ function paragraphMaybeWithTooltip(str, keyLength, maxWidth = 40) {
     <Box
       component="span"
     >
-      <ScrollIcon style={{height: '10px'}} />{inner}
+      {inner}
     </Box> : inner
   )
 }


### PR DESCRIPTION
Fixes:
  - Bunch of font-weight normalization
  - Uses css ellipsis to show truncated text.  Mouse-over toggles fields open.  Could be click, but maybe in a follow-up.  This seems strictly better.
  - Table and accordion had lots of padding tweaks that added up to some weird bugs where left text would underflow container.  I just zeroed a handful of these and started over
  - Switch track now visible after open.. could only find border.. bg color doesn't work for me yet.
  - Removed bottom borders on every field.. was partially confusing the groupings.  There seems to be enough horizontal structure from the table layout.